### PR TITLE
O(1) complexity of sizeOf() & standardized pop/push interface

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -4,7 +4,6 @@
     "func-order": "off",
     "mark-callable-contracts": "off",
     "no-empty-blocks": "off",
-    "compiler-version": ["error", "0.6.0"],
-    "private-vars-leading-underscore": "error"
+    "compiler-version": ["error", "0.6.0"]
   }
 }

--- a/contracts/StructuredLinkedList.sol
+++ b/contracts/StructuredLinkedList.sol
@@ -20,6 +20,7 @@ library StructuredLinkedList {
     bool private constant _NEXT = true;
 
     struct List {
+        uint256 size;
         mapping(uint256 => mapping(bool => uint256)) list;
     }
 
@@ -29,12 +30,7 @@ library StructuredLinkedList {
      * @return bool true if list exists, false otherwise
      */
     function listExists(List storage self) internal view returns (bool) {
-        // if the head nodes previous or next pointers both point to itself, then there are no items in the list
-        if (self.list[_HEAD][_PREV] != _HEAD || self.list[_HEAD][_NEXT] != _HEAD) {
-            return true;
-        } else {
-            return false;
-        }
+        return self.size > 0;
     }
 
     /**
@@ -45,31 +41,20 @@ library StructuredLinkedList {
      */
     function nodeExists(List storage self, uint256 _node) internal view returns (bool) {
         if (self.list[_node][_PREV] == _HEAD && self.list[_node][_NEXT] == _HEAD) {
-            if (self.list[_HEAD][_NEXT] == _node) {
-                return true;
-            } else {
-                return false;
-            }
-        } else {
-            return true;
+            return self.list[_HEAD][_NEXT] == _node;
         }
+
+        return true;
     }
 
     /**
      * @dev Returns the number of elements in the list
+     *      NOTE(pb): Function left just for backward compatibility, the `List.size` shall be used directly instead.
      * @param self stored linked list from contract
      * @return uint256
      */
     function sizeOf(List storage self) internal view returns (uint256) {
-        bool exists;
-        uint256 i;
-        uint256 numElements;
-        (exists, i) = getAdjacent(self, _HEAD, _NEXT);
-        while (i != _HEAD) {
-            (exists, i) = getAdjacent(self, i, _NEXT);
-            numElements++;
-        }
-        return numElements;
+        return self.size;
     }
 
     /**
@@ -134,9 +119,8 @@ library StructuredLinkedList {
         if (sizeOf(self) == 0) {
             return 0;
         }
-        bool exists;
-        uint256 next;
-        (exists, next) = getAdjacent(self, _HEAD, _NEXT);
+
+        (, uint256 next) = getAdjacent(self, _HEAD, _NEXT);
         while ((next != 0) && ((_value < StructureInterface(_structure).getValue(next)) != _NEXT)) {
             next = self.list[next][_NEXT];
         }
@@ -145,11 +129,13 @@ library StructuredLinkedList {
 
     /**
      * @dev Creates a bidirectional link between two nodes on direction `_direction`
+     *      NOTE(pb): This method shall *NOT* be used directly, since it allows to
+     *                create disjoint sub-list (= separated/disconnected from the rest of the list)
      * @param self stored linked list from contract
      * @param _node first node for linking
      * @param _link  node to link to in the _direction
      */
-    function createLink(List storage self, uint256 _node, uint256 _link, bool _direction) internal {
+    function _createLink(List storage self, uint256 _node, uint256 _link, bool _direction) internal {
         self.list[_link][!_direction] = _node;
         self.list[_node][_direction] = _link;
     }
@@ -165,12 +151,15 @@ library StructuredLinkedList {
     function insert(List storage self, uint256 _node, uint256 _new, bool _direction) internal returns (bool) {
         if (!nodeExists(self, _new) && nodeExists(self, _node)) {
             uint256 c = self.list[_node][_direction];
-            createLink(self, _node, _new, _direction);
-            createLink(self, _new, c, _direction);
+            _createLink(self, _node, _new, _direction);
+            _createLink(self, _new, c, _direction);
+
+            self.size += 1; // NOTE(pb): In theory, the SafeMath library should be used here to increment.
+
             return true;
-        } else {
-            return false;
         }
+
+        return false;
     }
 
     /**
@@ -205,9 +194,17 @@ library StructuredLinkedList {
         if ((_node == _NULL) || (!nodeExists(self, _node))) {
             return 0;
         }
-        createLink(self, self.list[_node][_PREV], self.list[_node][_NEXT], _NEXT);
+
+        // NOTE(pb): Intentionally using assert instead of require, since violation of the condition
+        //           shall *NOT* happen in any circumstances.
+        assert(self.size > 0);
+
+        _createLink(self, self.list[_node][_PREV], self.list[_node][_NEXT], _NEXT);
         delete self.list[_node][_PREV];
         delete self.list[_node][_NEXT];
+
+        self.size -= 1;
+
         return _node;
     }
 
@@ -215,23 +212,39 @@ library StructuredLinkedList {
      * @dev Pushes an entry to the head of the linked list
      * @param self stored linked list from contract
      * @param _node new entry to push to the head
-     * @param _direction push to the head (_NEXT) or tail (_PREV)
      * @return bool true if success, false otherwise
      */
-    function push(List storage self, uint256 _node, bool _direction) internal returns (bool) {
-        return insert(self, _HEAD, _node, _direction);
+    function pushFront(List storage self, uint256 _node) internal returns (bool) {
+        return insert(self, _HEAD, _node, _NEXT);
     }
 
     /**
      * @dev Pops the first entry from the linked list
      * @param self stored linked list from contract
-     * @param _direction pop from the head (_NEXT) or the tail (_PREV)
      * @return uint256 the removed node
      */
-    function pop(List storage self, bool _direction) internal returns (uint256) {
-        bool exists;
-        uint256 adj;
-        (exists, adj) = getAdjacent(self, _HEAD, _direction);
+    function popFront(List storage self) internal returns (uint256) {
+        (, uint256 adj) = getAdjacent(self, _HEAD, _NEXT);
+        return remove(self, adj);
+    }
+
+    /**
+     * @dev Pushes an entry to the tail/back of the linked list
+     * @param self stored linked list from contract
+     * @param _node new entry to push to the tail/back
+     * @return bool true if success, false otherwise
+     */
+    function pushBack(List storage self, uint256 _node) internal returns (bool) {
+        return insert(self, _HEAD, _node, _PREV);
+    }
+
+    /**
+     * @dev Pops the first entry from the tail/back of the linked list
+     * @param self stored linked list from contract
+     * @return uint256 the removed node
+     */
+    function popBack(List storage self) internal returns (uint256) {
+        (, uint256 adj) = getAdjacent(self, _HEAD, _PREV);
         return remove(self, adj);
     }
 }

--- a/contracts/StructuredLinkedList.sol
+++ b/contracts/StructuredLinkedList.sol
@@ -130,7 +130,7 @@ library StructuredLinkedList {
     /**
      * @dev Creates a bidirectional link between two nodes on direction `_direction`
      *      NOTE(pb): This method shall *NOT* be used directly, since it allows to
-     *                create disjoint sub-list (= separated/disconnected from the rest of the list)
+     *                create disjoint sub-list (= separated/disconnected from the rest of the main list)
      * @param self stored linked list from contract
      * @param _node first node for linking
      * @param _link  node to link to in the _direction

--- a/contracts/mocks/StructuredLinkedListMock.sol
+++ b/contracts/mocks/StructuredLinkedListMock.sol
@@ -74,11 +74,19 @@ contract StructuredLinkedListMock {
         emit LogNotice(_list.remove(_node) > 0 ? true : false);
     }
 
-    function push(uint256 _node, bool _direction) public {
-        emit LogNotice(_list.push(_node, _direction));
+    function pushFront(uint256 _node) public {
+        emit LogNotice(_list.pushFront(_node));
     }
 
-    function pop(bool _direction) public {
-        emit LogNotice(_list.pop(_direction) > 0 ? true : false);
+    function popFront() public {
+        emit LogNotice(_list.popFront() > 0 ? true : false);
+    }
+
+    function pushBack(uint256 _node) public {
+        emit LogNotice(_list.pushBack(_node));
+    }
+
+    function popBack() public {
+        emit LogNotice(_list.popBack() > 0 ? true : false);
     }
 }

--- a/test/StructuredLinkedList.test.js
+++ b/test/StructuredLinkedList.test.js
@@ -377,9 +377,9 @@ contract('StructuredLinkedList', function ([owner]) {
         });
 
         context('testing pop', function () {
-          describe('pop from HEAD', function () {
+          describe('popFront', function () {
             beforeEach(async function () {
-              const { logs } = await this.list.pop(NEXT);
+              const { logs } = await this.list.popFront();
 
               expectEvent.inLogs(logs, 'LogNotice', {
                 booleanValue: true,
@@ -413,9 +413,9 @@ contract('StructuredLinkedList', function ([owner]) {
             });
           });
 
-          describe('pop from TAIL', function () {
+          describe('popBack', function () {
             beforeEach(async function () {
-              const { logs } = await this.list.pop(PREV);
+              const { logs } = await this.list.popBack();
 
               expectEvent.inLogs(logs, 'LogNotice', {
                 booleanValue: true,
@@ -459,9 +459,9 @@ contract('StructuredLinkedList', function ([owner]) {
             thirdTokenId = await this.list.progressiveId();
           });
 
-          describe('push to HEAD', function () {
+          describe('pushFront', function () {
             beforeEach(async function () {
-              const { logs } = await this.list.push(thirdTokenId, NEXT);
+              const { logs } = await this.list.pushFront(thirdTokenId);
 
               expectEvent.inLogs(logs, 'LogNotice', {
                 booleanValue: true,
@@ -484,9 +484,9 @@ contract('StructuredLinkedList', function ([owner]) {
             });
           });
 
-          describe('push to TAIL', function () {
+          describe('pushBack', function () {
             beforeEach(async function () {
-              const { logs } = await this.list.push(thirdTokenId, PREV);
+              const { logs } = await this.list.pushBack(thirdTokenId);
 
               expectEvent.inLogs(logs, 'LogNotice', {
                 booleanValue: true,

--- a/test/StructuredLinkedList.test.js
+++ b/test/StructuredLinkedList.test.js
@@ -3,9 +3,6 @@ const { BN, expectEvent } = require('@openzeppelin/test-helpers');
 const HEAD = new BN(0);
 const INVALID_TOKEN_ID = new BN(111);
 
-const PREV = false;
-const NEXT = true;
-
 const StructuredLinkedList = artifacts.require('StructuredLinkedListMock.sol');
 
 contract('StructuredLinkedList', function ([owner]) {


### PR DESCRIPTION
1) O(1) impl. of `sizeOf()`, reduction from O(n), rather taking
   slight performance impact of increment/decrement of `uint256`
   on per each insert/remove operation.

2) Aligning pop/push interface with well established pattern & naming
   convention (e.g. see C++ STL `std::list<T>` container, or
   conceptually the same Java' `Deque<T>` or .NET'
   `LinkedList<T>`).
   This also makes code more readable, and consuming a little bit less
   gas due to dropping one parameter from the functions.